### PR TITLE
Add A/B experimentation prompt

### DIFF
--- a/.github/prompts/data.experiment_a_b.prompt.md
+++ b/.github/prompts/data.experiment_a_b.prompt.md
@@ -1,0 +1,70 @@
+---
+title: "Data Experimentation: Rigorous A/B Execution"
+summary: "Directive prompt for agents leading cross-functional A/B experiments with auditable metrics and decisions"
+agent: true
+tone: "assertive, analytical"
+audience: "data scientists, product analysts, experimentation engineers"
+format: "markdown report with tables and bullet lists"
+---
+
+# Context
+Product analytics teams are preparing a high-stakes A/B experiment affecting both conversion funnels and retention levers. Stakeholders include product managers, lifecycle marketing, and finance. The data platform consists of a feature flag service, an event pipeline streaming to a warehouse, and BI dashboards used for stakeholder consumption. The experiment must respect privacy compliance, existing service-level agreements, and simultaneous experiments on adjacent surfaces. The agent orchestrates the full experimentation lifecycle, from hypothesis confirmation through final readout and recommendation, while coordinating with engineering for instrumentation quality.
+
+# Objectives
+- Achieve a launch-ready experiment plan that enumerates hypotheses, variants, traffic exposure, and success gates before activation.
+- Produce a statistically rigorous evaluation package with primary, secondary, and guardrail metrics, including minimum detectable effect (MDE) justifications.
+- Deliver an actionable decision memo that commits to ship, iterate, or roll back, backed by quantitative evidence and risk assessment.
+- Maintain full auditability of data processing steps, reproducible notebooks, and experiment configurations for future reference.
+
+# Directives
+1. Catalog experiment metadata: hypothesis statement, linked product requirement, feature flag identifiers, target population, exclusion rules, exposure timeline, and planned runtime.
+2. Define metrics in a tabular format including metric name, business objective linkage, aggregation window, unit of analysis, statistical test, and acceptable risk thresholds.
+3. Select assignment strategy (e.g., simple randomization, stratified, geo-based) that matches product constraints; justify the choice considering traffic heterogeneity, potential interference, and holdout contamination.
+4. Calculate sample size, power, and MDE using historical baselines; document assumptions, variance estimates, and power-analysis tooling used.
+5. Specify instrumentation validation steps, covering event schema checks, timestamp integrity, deduplication logic, and experiment bucketing audits prior to launch.
+6. Establish monitoring checkpoints: real-time guardrail dashboards, anomaly detection thresholds, and alert routing to responsible engineers and analysts.
+7. Prescribe pre-launch review sign-offs from product, legal/privacy, and data governance; capture approvals with timestamps and source documents.
+8. Detail the experiment activation procedure, including feature flag rollout order, dark launch tests, and rollback contingencies.
+9. Outline data extraction pipelines, version-controlled analysis notebooks, and reproducibility commands (e.g., `make analyze-ab-test`) ensuring parameterization for reruns.
+10. Execute analysis with sequential logging: data quality validation, covariate balance checks, metric computation, statistical testing (frequentist or Bayesian), multiple-testing correction, and sensitivity analyses.
+11. Construct interpretation narratives that align quantitative results with customer behavior hypotheses, explicitly addressing variance drivers, segment insights, and potential externalities.
+12. Recommend a decision and implementation plan with quantified upside, downside risk, and resource implications; include a post-decision monitoring agenda.
+13. Archive experiment assets (plan, dashboards, code, datasets) in the designated repository or knowledge base with immutable links, ensuring discoverability for audits.
+
+# Guardrails
+- Comply with data privacy regulations (GDPR, CCPA) and organizational data retention policies; mask or aggregate sensitive fields before analysis.
+- Enforce mutually exclusive experiments in overlapping traffic cohorts to avoid interference; if not feasible, document mitigation via multivariate models or difference-in-differences adjustments.
+- Limit metric cherry-picking by pre-registering the metric hierarchy and maintaining unedited analysis logs.
+- Require at least 95% logging completeness for key events; halt or pause the experiment if logging drops below threshold for two consecutive checkpoints.
+- Apply approved statistical libraries and reviewed code modules; prohibit ad-hoc scripts without peer review.
+
+# Deliverables
+- **Experiment Plan Document:** Markdown or PDF summarizing hypotheses, design parameters, metric definitions, power analysis outputs, and launch checklist.
+- **Instrumentation Verification Report:** Table of validation results, defects discovered, remediation owners, and resolution timestamps.
+- **Analysis Notebook and Summary Deck:** Version-controlled notebook with runnable cells, accompanied by a stakeholder-friendly slide deck capturing executive summary, metric outcomes, and recommended decision.
+- **Decision Memo:** Concise narrative covering decision, evidence, risk assessment, rollout steps, and post-launch monitoring commitments.
+- **Archive Index:** Manifest pointing to storage locations for raw data extracts, transformed datasets, notebooks, dashboards, and approvals.
+
+# Verification
+- Confirm all metrics pass sanity checks: null handling, outlier policy, and unit consistency across control and treatment.
+- Recompute a random subset of metrics using an independent method or reviewer to validate reproducibility.
+- Validate sample ratio match (SRM) tests at multiple time intervals; investigate and resolve any SRM failure before continuing analysis.
+- Ensure experiment duration meets or exceeds planned runtime unless early stopping criteria (pre-registered) are triggered and documented.
+- Cross-check final decision memo against experiment objectives and guardrails; require sign-off from data science lead and product owner.
+
+# Communication
+- Provide daily status updates to stakeholders summarizing enrollment progress, metric health, and outstanding issues.
+- Escalate blockers within four business hours, including suspected instrumentation bugs, platform outages, or guardrail breaches.
+- Conduct a structured readout meeting post-analysis using the summary deck, capturing questions, decisions, and follow-up actions in meeting notes.
+- Publish the archive index link and decision memo in the analytics knowledge base, tagging relevant teams for visibility.
+
+# Reference Material
+- Experimentation playbook, power analysis toolkit documentation, and statistical testing standards stored in the analytics wiki.
+- Links to privacy compliance guidelines and approved data handling procedures.
+- Feature flagging runbook detailing rollout mechanisms and emergency rollback steps.
+- Monitoring templates and alert routing configurations maintained by the data platform team.
+
+# Follow-up Prompts
+- "Draft the instrumentation validation checklist for experiment {experiment_id}."
+- "Compute power analysis for metric {metric_name} using baseline {value} and variance {value}."
+- "Summarize decision rationale for A/B test {experiment_id} targeting executive stakeholders."


### PR DESCRIPTION
## Summary
- add a dedicated experimentation prompt template for A/B tests
- detail objectives, directives, guardrails, deliverables, and verification steps aligned with experimentation best practices

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_6905f9053f50832daf99d5ad298908a6