### PR TITLE
Add automated build delivery prompt

### DIFF
--- a/.github/prompts/delivery.build_scripts.prompt.md
+++ b/.github/prompts/delivery.build_scripts.prompt.md
@@ -1,0 +1,66 @@
+---
+title: "Automated Build Delivery"
+summary: "Directive for automating build orchestration with caching and parallel execution to supersede manual workflows."
+agent: true
+style: "Decisive and technical"
+tone: "Authoritative"
+audience: "Build and release engineers"
+format: "Structured Markdown with numbered directives"
+---
+
+## Context
+Automated build delivery is replacing ad hoc manual scripts within a polyglot product portfolio that includes microservices, shared libraries, and client applications deployed across Linux and Windows runners. The delivery organization manages nightly integration pipelines, on-demand release candidates, and hotfix branches; manual execution currently causes inconsistent artifact provenance, dependency cache thrashing, and idle compute time. Stakeholders include release managers demanding reproducible provenance, QA engineers validating binary equivalence, SREs tracking infrastructure costs, and compliance auditors requiring traceable build metadata. The Copilot agent must assume access to CI providers (GitHub Actions and Azure Pipelines), artifact registries, infrastructure-as-code repositories, and telemetry dashboards exposing build performance indicators. Align with the delivery lead’s expectation that every change is auditable, failure-tolerant, and reversible without human intervention. 
+
+## Objectives
+- Replace manual build steps with deterministic, scriptable pipelines capable of running unattended on cloud runners.
+- Exploit caching layers (dependency caches, Docker layer caches, compiler caches) to minimize cold-start times while ensuring cache invalidation rules prevent stale outputs.
+- Parallelize workloads to saturate available compute, including matrix builds for OS and architecture combinations, without exceeding concurrency quotas.
+- Instrument build scripts to emit structured logs, performance metrics, and provenance records consumable by downstream analytics and audits.
+- Deliver a repeatable implementation blueprint, reference scripts, and validation evidence that authorize decommissioning of legacy manual builds.
+
+## Directives
+1. Assess existing manual build entry points, shell scripts, and documentation to enumerate required targets, dependencies, and environment variables. Capture gaps or ambiguities as clarifying questions before implementation.
+2. Design a layered automation architecture: reusable core scripts (Bash or PowerShell), language-specific build modules (Gradle, npm, cargo, etc.), and CI pipeline definitions orchestrating the modules. Diagram handoffs and sequencing in Markdown tables.
+3. Specify caching strategies per build stage, referencing exact cache keys, scope (branch, workflow, job), eviction policies, and validation hooks that confirm cache freshness before reuse.
+4. Plan parallelization by mapping tasks to CI runners, enabling matrix strategies for platform variants, and splitting long-running stages into discrete jobs guarded by dependency graphs. Ensure resource tags honor licensing and hardware constraints.
+5. Author idempotent build scripts that consume configuration from version-controlled manifests, enforce environment setup (toolchains, secrets, service endpoints), and fail fast with actionable diagnostics.
+6. Embed provenance logging: generate SBOMs, checksums, compiler flags, and environment fingerprints. Store artifacts in the organization’s registry with retention policies noted in the plan.
+7. Integrate automated verification steps (unit, integration, smoke tests) into the pipeline, gating artifact publication on successful test suites and static analysis reports.
+8. Define rollback and retry behaviors, including how to invalidate caches, rerun failed jobs, and notify stakeholders when automated recovery is triggered.
+9. Produce a change management proposal outlining migration milestones, success metrics, and a training plan for operators transitioning off manual procedures.
+10. Submit a final execution strategy summarizing architecture, scripts, configuration snippets, risk mitigations, and next actions in the prescribed deliverable format.
+
+## Guardrails
+- Adhere to organizational security policies: treat secrets via approved vaults, enforce least privilege on service accounts, and document credential rotation cadences.
+- Ensure all scripts are cross-platform or provide OS-specific fallbacks documented in the migration plan.
+- Constrain pipeline modifications to deterministic tools; avoid introducing experimental or unlicensed dependencies.
+- Use reproducible tooling versions pinned via lockfiles or container images, with upgrade procedures described for future maintainers.
+- Prioritize maintainability: modularize scripts, document functions inline, and align naming with existing repository conventions.
+
+## Deliverables
+- Automation blueprint detailing pipeline topology, job dependencies, cache schemas, and parallelization rationale in Markdown with tables or diagrams.
+- Repository-ready build scripts or configuration files (e.g., `build.sh`, `build.ps1`, `azure-pipelines.yml`, `.github/workflows/*.yml`) annotated with usage instructions and required inputs.
+- Validation report summarizing cache hit ratios, parallel execution benchmarks, artifact integrity checks, and regression test outcomes.
+- Migration schedule showing phased rollout, fallback triggers, and owner assignments for each milestone.
+- Executive summary for delivery leadership highlighting benefits, risk mitigations, and support requirements.
+
+## Verification
+- Execute dry-run builds on representative branches (feature, release, hotfix) and record timings, cache performance, and parallel job completion order.
+- Confirm reproducibility by running identical builds on fresh runners and verifying artifact checksums and SBOM signatures match previous outputs.
+- Validate cache invalidation by introducing controlled dependency updates and demonstrating that stale caches are bypassed.
+- Review logs for completeness: ensure structured metadata (commit SHA, job ID, toolchain versions) is captured and stored in centralized telemetry.
+- Conduct peer review of scripts and pipeline definitions for readability, security posture, and adherence to coding standards.
+- Demonstrate rollback by simulating a failed job, executing the documented recovery path, and verifying stakeholders receive alerts via designated channels.
+
+## Communication
+- Provide daily progress summaries in the delivery team’s channel, highlighting completed tasks, metrics observed, and next steps.
+- Escalate blockers or resource constraints immediately to the release manager, including proposed remediation options.
+- Record significant design decisions in the engineering journal with links to relevant commits, diagrams, and approvals.
+- Notify QA and SRE teams before running high-impact or resource-intensive pipeline experiments, supplying estimated timelines and rollback plans.
+- Publish the final automation package and verification evidence to the knowledge base, tagging stakeholders for acknowledgment.
+
+## Reference Material
+- Internal CI/CD standards documentation and security hardening guides.
+- GitHub Actions cache and matrix strategy documentation.
+- Azure Pipelines caching and parallel job configuration references.
+- Organization’s artifact registry usage handbook and SBOM generation policy.


### PR DESCRIPTION
## Summary
- add a delivery-focused prompt guiding agents on automating build orchestration with caching and parallel execution
- define objectives, directives, guardrails, verification, and communication practices tailored to replacing manual builds

## Testing
- not run (not required)

------
https://chatgpt.com/codex/tasks/task_e_6905f90c83fc832dbbc9c6321dc3019c