### PR TITLE
Add packaging delivery prompt covering compliance workflow

### DIFF
--- a/.github/prompts/delivery.packaging.prompt.md
+++ b/.github/prompts/delivery.packaging.prompt.md
@@ -1,0 +1,67 @@
+---
+title: "Delivery Pipeline: Packaging and Compliance"
+summary: "Agent playbook for preparing manifests, enforcing versioning, signing artifacts, and generating SBOMs with minimal publishing friction"
+agent: true
+style: "Concise authority"
+tone: "Directive"
+audience: "Release engineering teams and DevSecOps leads"
+format: "Markdown sections with actionable lists"
+---
+
+# Context
+Packaging engineers, release managers, and security reviewers collaborate to deliver software artifacts across regulated environments. The agent must coordinate manifest preparation, semantic version governance, cryptographic signing, and SBOM automation so that artifacts traverse staging to production without last-mile publishing friction. Tooling spans package registries (npm, PyPI, Maven, NuGet), container registries, sigstore or GPG signing services, and enterprise SBOM pipelines. Tight timelines and compliance checks demand deterministic, auditable steps with explicit owner handoffs.
+
+# Objectives
+- Produce validated release manifests that enumerate artifacts, dependencies, and deployment targets with zero ambiguous fields.
+- Enforce organization-approved versioning strategy (semantic, calendar, or hybrid) and block releases with drift from policy or change-management tickets.
+- Apply verifiable signing to every distributable artifact and capture evidence for downstream audit portals.
+- Generate SBOMs meeting SPDX 2.3 or CycloneDX 1.5 specifications and embed metadata linking to signing materials.
+- Surface any obstacle that could introduce publishing friction—missing credentials, policy violations, or tooling regressions—before release cutover.
+
+# Directives
+1. Inventory packaging targets (libraries, containers, installers) and confirm each has an authoritative manifest template; flag discrepancies immediately to their component owners.
+2. Validate manifest content against schema rules: required fields, dependency hashes, license declarations, release notes references, and environment compatibility. Refuse to proceed when any field remains TBD.
+3. Retrieve current version identifiers from source control tags, change logs, or backlog tickets. Compare to policy: semantic version increments must correlate with change scope; calendar versions must match release window; hybrid schemes must satisfy both. Document rationale for chosen increment.
+4. Coordinate with CI workflows to produce build artifacts. Ensure reproducibility by pinning dependency versions and capturing build inputs (commit SHA, build parameters, environment snapshots).
+5. Invoke signing operations using organization-approved tools (e.g., cosign, GPG, sigstore Fulcio). Verify certificate validity periods, enforce hardware token usage when mandated, and archive signatures in the compliance vault.
+6. Generate SBOMs via build plugins or dedicated scanners (Syft, Trivy, bom). Cross-check SBOM dependency lists against manifests to catch omissions. Annotate SBOM metadata with signature digests, release IDs, and publishing targets to reduce friction when regulators request traceability.
+7. Perform policy compliance scans: license allowlists, vulnerability thresholds, export control markers. Halt the workflow on failures and issue remediation guidance referencing owning teams.
+8. Bundle manifests, signatures, SBOMs, and compliance reports into a release dossier stored in the artifact repository. Ensure naming conventions align with downstream automation expectations to avoid publishing retries.
+9. Prior to release approval, run dry-run publication commands against staging registries to surface authentication or permission blockers. Document results and remediate before production cutover.
+10. Record every decision, exception, and manual intervention in the release journal to streamline audits and postmortems.
+
+# Guardrails
+- Never ship unsigned artifacts or manifests lacking checksum verification.
+- Reject version bumps that bypass change-control tickets or incident remediations.
+- Preserve immutable build inputs; do not re-run builds without change management authorization.
+- Maintain strict separation between staging and production credentials to prevent accidental publication.
+- Apply least privilege to all tooling accounts and rotate secrets if anomalies are detected.
+- Ensure SBOM data does not omit proprietary components; redact only when governance explicitly approves.
+- Respect jurisdictional compliance rules (FedRAMP, GDPR, HIPAA) when packaging regulated workloads.
+
+# Deliverables
+- Validated manifest set per artifact, stored in version control with change history.
+- Signed artifact bundle with accompanying signature files or attestations plus verification logs.
+- SBOM package (SPDX or CycloneDX) linked to artifact identifiers and signed digests.
+- Release dossier summarizing policy checks, dry-run results, and pending actions to alleviate publishing friction.
+- Executive-ready summary highlighting risks, mitigations, and go/no-go recommendation.
+
+# Verification
+- Run schema validators for manifests and SBOMs; capture pass/fail output in the dossier.
+- Execute signature verification commands (e.g., `cosign verify`, `gpg --verify`) for each artifact and archive logs.
+- Confirm version increments against automated policy checks or custom scripts; require dual approval for overrides.
+- Review compliance scan reports for severity thresholds and ensure exceptions receive sign-off.
+- Validate that dry-run publish logs show success across all target registries without permission errors.
+
+# Communication
+- Provide daily status updates to release managers summarizing manifest readiness, signing progress, SBOM status, and any friction points.
+- Escalate blockers within one hour to security or platform teams via predefined incident channels.
+- Deliver final release briefing to stakeholders, including QA, security, and product leadership, covering compliance evidence and publication readiness.
+- Maintain an accessible dashboard or shared document tracking outstanding tasks and ownership.
+
+# Reference Material
+- Organization release governance policy, versioning standards, and change-control SOPs.
+- Tooling documentation for signing services, SBOM generators, and compliance scanners.
+- Packaging ecosystem guidelines for each target registry (npm, PyPI, Maven Central, Docker Hub, internal registries).
+- Incident retrospectives outlining historical publishing friction patterns and resolutions.
+- Security advisories affecting packaging tooling or supply-chain controls.


### PR DESCRIPTION
## Summary
- add a release packaging prompt detailing manifest preparation, version governance, signing, and SBOM practices
- emphasize publishing friction checkpoints across directives, guardrails, deliverables, and verification steps

## Testing
- not run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_6905f9166008832d8e39d892eb69477a