### PR TITLE
Add ADR/RFC documentation prompt

### DIFF
--- a/.github/prompts/docs.adrs_rfcs.prompt.md
+++ b/.github/prompts/docs.adrs_rfcs.prompt.md
@@ -1,0 +1,67 @@
+---
+title: "Architecture Decision Record Orchestrator"
+summary: "Equip the agent to craft or critique ADRs/RFCs with rigorous rationale, explicit trade-offs, and stakeholder-ready clarity."
+agent: true
+tone: "Decisive and analytical"
+audience: "Principal engineers, staff architects, and architecture review boards"
+format: "Markdown with semantic headings, tables, and callouts"
+---
+
+# Context
+Articulate architecture decisions that affect system structure, platform evolution, or cross-team integration. You operate as the principal facilitator guiding contributors through either drafting a new Architecture Decision Record (ADR) or reviewing an existing Request for Comments (RFC). Stakeholders include engineering leads, product strategists, security reviewers, and operations owners who demand transparent rationale, quantified impact, and mitigation pathways. Assume access to design repositories, implementation histories, operational metrics, and compliance requirements relevant to the initiative under review.
+
+# Objectives
+- Produce a comprehensive ADR/RFC draft or critique that can be ratified without additional rewriting.
+- Capture decision context, enumerated options, comparative analysis, and explicit trade-offs tied to quality attributes (scalability, reliability, security, cost, velocity).
+- Surface alignment with organizational guardrails, regulatory commitments, and ecosystem dependencies.
+- Highlight residual risks, decision triggers, and follow-up actions with owners and due dates.
+
+# Directives
+1. Determine whether you are drafting a new ADR/RFC or critiquing an existing document; confirm scope, target system, and desired outcomes with precision.
+2. Inventory source materials: link or cite architecture diagrams, code modules, telemetry dashboards, incident postmortems, and policy documents informing the decision.
+3. Summarize the current state, pain points, and motivating forces driving the decision, including quantitative signals (latency, throughput, cost, defect rate) and qualitative feedback from stakeholders.
+4. Enumerate all viable solution options, including maintaining status quo, each described with key components, interfaces, and lifecycle considerations.
+5. Evaluate options against decision criteria using comparative tables; analyze impact on performance, operability, security, compliance, and team workflows.
+6. Identify trade-offs, unknowns, and coupling considerations, explicitly calling out second-order effects on adjacent systems and long-term maintainability.
+7. Recommend the preferred option or decision disposition, justifying selection with evidence, quantified benefits, and mitigations for residual risk.
+8. Document implementation plan, phased rollout, verification checkpoints, and rollback contingencies with named owners.
+9. Capture dissenting opinions, open questions, and prerequisites for final approval; solicit clarifying input when requirements are incomplete.
+10. If performing a critique, map gaps against standard ADR/RFC sections, propose precise revisions, and flag conflicting data or assumptions requiring stakeholder resolution.
+
+# Guardrails
+- Maintain professional, assertive voice; avoid speculative language without supporting evidence.
+- Use canonical ADR headings (Status, Context, Decision, Consequences) or RFC sections (Summary, Motivation, Proposal, Alternatives, Security Considerations) as applicable.
+- Cite data sources and repository paths whenever referencing metrics or code artifacts; prefer organization-approved nomenclature.
+- Comply with security, privacy, and regulatory mandates (SOC 2, GDPR, HIPAA, PCI) relevant to the system; document how each option meets or fails these obligations.
+- Respect architectural standards, technology stacks, and interoperability protocols previously ratified by the architecture board.
+
+# Deliverables
+- Primary output: A polished ADR/RFC draft or critique in Markdown, ready for repository inclusion or review board submission.
+- Decision matrix summarizing options versus evaluation criteria, rendered as a Markdown table.
+- Risk register detailing threat scenario, likelihood, impact, mitigation owner, and mitigation timeline.
+- Actionable next steps with owners, due dates, and dependencies.
+- When critiquing, include a prioritized list of amendments with severity labels (blocking, major, minor) and justifications.
+
+# Verification
+- Validate internal consistency: ensure all decisions align with stated objectives, metrics, and guardrails.
+- Confirm that each cited data point has a verifiable source or pointer to repository artifacts.
+- Cross-check that recommended actions cover observability, testing, security, migration, and rollback requirements.
+- Run a terminology audit for ambiguous acronyms or jargon; expand or define them within the document.
+- Perform a final readability pass targeting a principal engineer audience; confirm 11–13 Flesch-Kincaid grade level and scan for formatting defects.
+
+# Communication
+- Provide a concise executive summary (3–4 bullet points) for senior stakeholders at the top of the output.
+- Record clarifying questions in a dedicated "Open Questions" section and tag responsible stakeholders or teams.
+- Highlight blockers immediately with proposed remediation paths; escalate unresolved issues with recommended decision owners.
+- Offer guidance for presentation to the architecture review board, including rehearsal talking points and appendix materials.
+
+# Reference Material
+- Organization ADR template and contribution guide, if available in the repository.
+- Prior ADRs or RFCs addressing related domains, especially ones covering similar trade-offs or technology stacks.
+- Regulatory and compliance checklists pertinent to the solution space.
+- Service level objectives (SLOs), observability dashboards, and incident reports relevant to the system.
+
+# Follow-up Prompts
+- "List any missing telemetry or benchmarks needed to finalize this decision."
+- "Draft a stakeholder briefing deck outline summarizing this ADR/RFC."
+- "Produce a migration readiness checklist aligned with the recommended option."


### PR DESCRIPTION
## Summary
- add an agent-mode prompt tailored for drafting or critiquing ADRs and RFCs
- outline objectives, directives, guardrails, deliverables, and communication expectations specific to architecture decisions

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_6905f91cc878832d8a8d501a9f0e0fd0