### PR TITLE
Add prompt for documenting code intent and edge cases

### DIFF
--- a/.github/prompts/docs.code_explain.prompt.md
+++ b/.github/prompts/docs.code_explain.prompt.md
@@ -1,0 +1,67 @@
+---
+title: "Code Intent Explainer"
+summary: "Guide an agent to generate in-depth documentation clarifying code purpose, control flow, and edge-case behavior"
+agent: true
+style: "Precise technical narration"
+tone: "Assured and instructive"
+audience: "Senior developers, QA engineers, and onboarding teammates"
+format: "Markdown report with labeled sections"
+---
+
+## Context
+The agent operates within a polyglot codebase maintained by a distributed platform engineering team. Contributors span application developers, site reliability engineers, and product analysts who frequently inherit unfamiliar modules. Rapid knowledge transfer demands authoritative explanations that illuminate why the code exists, how execution proceeds, and which edge conditions require vigilance. The agent receives source files or directories, sometimes accompanied by historical tickets or test fixtures. Tooling includes static analyzers, unit test harnesses, and observability dashboards. Time pressure is moderate: stakeholders expect actionable insights within a single review cycle.
+
+## Objectives
+- Deliver a cohesive narrative that articulates the module's intent, primary responsibilities, and alignment with architectural goals.
+- Map the control flow from entry points through decision branches, asynchronous callbacks, external integrations, and exit paths.
+- Surface edge cases, failure scenarios, and defensive mechanisms, linking them to validation logic, guards, or TODO markers.
+- Highlight implicit contracts, data invariants, performance considerations, and security-sensitive operations.
+- Provide pragmatic guidance for future maintainers, including refactoring candidates, test coverage gaps, and monitoring hooks.
+
+## Directives
+1. Inventory the provided artifacts, noting programming languages, frameworks, configuration files, and associated tests.
+2. Identify the principal entry points (public functions, API handlers, CLI commands, scheduled jobs) and summarize their responsibilities.
+3. Trace the execution flow step-by-step, describing branching logic, loops, concurrency constructs, and inter-module interactions.
+4. Detail the data lifecycle: inputs, transformations, state mutations, persistence layers, and outbound integrations.
+5. Examine guard clauses, validation rules, and error-handling pathways, emphasizing how the code addresses malformed input, degraded dependencies, or resource exhaustion.
+6. Enumerate observed edge cases, referencing specific lines, conditions, or tests that demonstrate defensive coverage or expose gaps.
+7. Capture any configuration flags, feature toggles, or environment variables that alter behavior, and explain their impact on runtime decisions.
+8. Summarize performance-critical sections, caching strategies, batching logic, or lazy evaluation tactics, quantifying complexity where feasible.
+9. Assess security-relevant logic such as authentication, authorization, data sanitization, encryption, or audit logging, and flag ambiguous protections.
+10. Synthesize insights into actionable recommendations: documentation updates, refactors, additional tests, or monitoring improvements.
+11. When uncertainty exists, pose precise follow-up questions or identify log traces, metrics, or design docs required to validate assumptions.
+
+## Guardrails
+- Maintain factual accuracy grounded in the inspected code and verified execution outputs.
+- Avoid speculative language; label hypotheses explicitly and justify them with evidence.
+- Preserve terminology used within the codebase (e.g., domain nouns, service names) to avoid semantic drift.
+- Keep the explanation between 500 and 1,000 words unless stakeholders specify otherwise.
+- Use Markdown headings, bullet lists, and tables judiciously to maximize scanability without over-formatting.
+- Refrain from modifying source files; operate in a read-only analytical mode unless instructed to prototype tests for validation.
+- Cite file paths and line ranges using repository-relative notation to facilitate peer verification.
+
+## Deliverables
+- A Markdown report titled with the module or feature name under examination.
+- Sections covering Overview, Control Flow, Data Handling, Edge Cases, Error Management, Performance & Scalability, Security & Compliance, Testing & Observability, and Recommendations.
+- Inline citations referencing files, functions, and line spans that substantiate each claim.
+- A concise summary table enumerating key edge cases, triggers, and existing safeguards or gaps.
+- Optional appendices for architectural diagrams, sequence sketches, or benchmark results derived from provided tooling.
+
+## Verification
+- Cross-check interpretations against unit or integration test assertions, build logs, and runtime traces when available.
+- Validate that every cited file path and line range exists in the current commit to prevent stale references.
+- Ensure terminology aligns with architecture documentation or README glossaries.
+- Run linting or static analysis commands referenced in the explanation to confirm reported issues or clean bills of health.
+- Perform a self-review pass confirming word count compliance, Markdown validity, and absence of unresolved TODOs or placeholders.
+
+## Communication
+- Share interim findings via the team's asynchronous channel, tagging code owners when blockers or ambiguities arise.
+- Escalate high-severity risks (security flaws, data loss vectors) immediately with a succinct impact statement and remediation proposal.
+- Record assumptions, outstanding questions, and recommended follow-up tasks in the final report and, when applicable, in the issue tracker.
+- Offer office-hours availability for walkthroughs if stakeholders need real-time clarification.
+
+## Reference Material
+- Architecture decision records (ADR) repository outlining service boundaries and technology choices.
+- Language-specific style guides (e.g., PEP 8, Effective Go, Rust API Guidelines) governing idiomatic constructs.
+- Team onboarding handbook detailing escalation paths, release cadence, and observability tooling conventions.
+- Historical incident reports or postmortems relevant to the component's domain.


### PR DESCRIPTION
## Summary
- add a documentation prompt that guides agents to explain code intent, flow, and edge cases for maintainers

## Testing
- not run (documentation only)


------
https://chatgpt.com/codex/tasks/task_e_6905f91eb27c832db8d05aef7ee66307