### PR TITLE
Add product work summary prompt for stakeholder updates

### DIFF
--- a/.github/prompts/product.work_summary.prompt.md
+++ b/.github/prompts/product.work_summary.prompt.md
@@ -1,0 +1,60 @@
+---
+title: "Product Work Summary Prompt"
+summary: "Guide an agent to translate repository diffs into executive-ready product updates with clear success metrics"
+agent: true
+style: "Concise, outcome-driven"
+tone: "Confident and stakeholder-focused"
+audience: "Product and executive stakeholders"
+format: "Markdown report"
+---
+
+# Context
+Describe that the agent receives commit diffs, merged pull requests, and ancillary notes from engineers and must condense them into stakeholder-facing weekly updates. Clarify that the audience comprises product leadership, customer success, and go-to-market teams who need actionable signals without engineering jargon. Mention that the organization follows agile release trains, values measurable outcomes, and tracks feature readiness through launch gates (Discover, Build, Validate, Release).
+
+# Objectives
+- Produce a self-contained Markdown report covering the latest engineering work within the specified time window, organized by thematic pillars (e.g., "Collaboration", "Reliability", "Platform").
+- Translate technical code changes into user or business impact statements with quantified progress (percentage completion, milestone status, or customer counts) wherever data is available.
+- Surface dependencies, risks, and upcoming milestones so non-technical stakeholders can assess launch readiness.
+- Ensure every headline includes an explicit success metric, next step, or deadline.
+
+# Directives
+1. Start by listing the reporting window, data sources (commit SHAs, PR numbers, release notes), and any coverage gaps.
+2. Cluster related changes into 3-5 product themes; each theme must include a one-line executive summary followed by bullet points translating code changes into customer-facing benefits.
+3. For every bullet, cite the originating commit or PR identifier and restate the measurable impact (e.g., "% of rollout complete", "X customers in beta", "Error rate ↓ Y%").
+4. Highlight blockers or risks in a dedicated subsection that specifies owner, mitigation plan, and deadline.
+5. Call out cross-team dependencies, including the responsible team and the handoff artifact required.
+6. Provide a "Next Week Focus" section with top three priorities, each tied to a target metric or milestone gate.
+7. End with a "Notable Launch Metrics" table capturing at least: Feature, Current Stage (Discover/Build/Validate/Release), Confidence (High/Medium/Low), and Target Date.
+8. Use assertive, declarative sentences; avoid speculative language unless explicitly flagged as an assumption.
+9. Prompt for missing quantitative inputs if the source material lacks metrics, suggesting surrogate measures (e.g., number of test cases, adoption proxies).
+
+# Guardrails
+- Do not include raw diff text or low-level implementation details unless they directly affect user experience or delivery timelines.
+- Maintain confidentiality by redacting customer names unless written approval is present in source notes.
+- Ensure terminology aligns with the product team's roadmap taxonomy and launch-gate nomenclature.
+- Keep the report between 300 and 500 words to respect stakeholder reading time.
+- Follow the existing Markdown hierarchy: top-level sections with `##`, bullet lists with `-`, tables formatted using pipes, and bold emphasis reserved for metrics or deadlines.
+
+# Deliverables
+- One Markdown report adhering to the section order: Overview, Themes, Blockers & Risks, Dependencies, Next Week Focus, Notable Launch Metrics.
+- Each section must state clear success criteria or completion signals (e.g., "QA exit criteria met when automated regression passes at 98% confidence").
+- Include a final "Callouts for Leadership" bullet list summarizing decisions needed or approvals pending.
+
+# Verification
+- Cross-check that every theme bullet references at least one concrete data point or quantifiable proxy.
+- Confirm word count stays within the 300-500 range; if not, revise before delivering.
+- Validate that all tables render correctly in GitHub Markdown preview (no missing pipes, headers, or alignment issues).
+- Ensure every cited commit/PR identifier exists in the provided source list; flag discrepancies for follow-up.
+- Perform a language clarity pass, replacing acronyms with their expanded forms on first mention unless the audience is guaranteed to know them.
+
+# Communication
+- Begin the response with a one-paragraph executive overview summarizing major wins, risks, and upcoming decisions.
+- Close with explicit requests for input (e.g., "Confirm GA launch gate by Friday") and tag responsible stakeholders if collaboration tooling permits.
+- Offer to supply supplementary engineering detail upon request, noting where deeper technical threads live (e.g., specific design docs or PR discussions).
+
+# Reference Material
+- Link to the roadmap tracker, KPI dashboard, and launch readiness checklist when they provide quantitative context.
+- Provide template phrasing for common product metrics (activation, retention, latency) to maintain consistency across reports.
+
+# Follow-up Prompts
+List clarification questions the agent should ask when metrics are missing, dependencies are unclear, or new risks emerge.


### PR DESCRIPTION
## Summary
- add a product work summary prompt that guides agents to convert diffs into stakeholder-facing updates
- define objectives, directives, and guardrails emphasizing measurable metrics and clarity
- document verification and communication expectations for consistent executive reporting

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_6905f93f04f4832daff12a0ed8f9b7a9