### PR TITLE
Add profiling operations prompt

### DIFF
--- a/.github/prompts/operate.profiling.prompt.md
+++ b/.github/prompts/operate.profiling.prompt.md
@@ -1,0 +1,60 @@
+---
+title: "Profiler Operations Runbook"
+summary: "Orchestrates deterministic profiler setup, trace interpretation, and hotspot remediation guidance for production-grade services"
+agent: true
+audience: "Site reliability engineers and performance specialists"
+tone: "Directive, high-confidence"
+---
+
+## Context
+The primary service is a latency-sensitive microservice cluster handling interactive workloads across Kubernetes namespaces `core-io` and `ingest-stream`. Profiling occurs against Linux hosts instrumented with eBPF-capable kernels and observability stacks (Grafana, Prometheus, Jaeger). Stakeholders include SREs, platform engineers, and staff developers accountable for keeping p99 latency under 120 ms while scaling weekly releases. The agent operates during scheduled performance investigations with maintenance windows negotiated through the change-management portal. Assume SSH access, sudo privileges, and secure artifact storage in the `perf-insights` S3 bucket.
+
+## Objectives
+- Establish a repeatable profiler configuration tailored to CPU, memory, and I/O analysis without disrupting baseline SLIs.
+- Generate trace captures that isolate regressions introduced in the latest deployment batch.
+- Distill hotspots into ranked remediation candidates with quantified impact on latency and resource efficiency.
+- Deliver actionable reports consumable by engineering leads and program managers.
+
+## Directives
+1. **Validate preconditions**: Confirm maintenance window, traffic-shedding plan, and data-retention approval from the runbook ticket. Abort if any prerequisite is absent.
+2. **Calibrate environment**: Snapshot current system metrics (CPU, memory, I/O queues) via `sar`, `pidstat`, and cluster dashboards, storing raw outputs under `perf-insights/baselines/<timestamp>/`.
+3. **Select profiler**: Choose between `perf`, `py-spy`, `async-profiler`, or `Pixie` according to language runtime, containerization constraints, and sampling overhead. Document rationale in the session log.
+4. **Instrument targets**: Apply profiler flags for symbol resolution, frame pointer requirements, and sampling intervals. For Java, enable `-XX:+UnlockCommercialFeatures` when necessary; for Go, configure `GODEBUG=asyncpreemptoff=1` if high-frequency sampling distorts results.
+5. **Capture traces**: Run at least two controlled traffic scenarios—baseline workload replay and high-load stress test—ensuring trace durations capture steady-state behavior (minimum 120 seconds). Store raw artifacts in S3 with SHA256 checksums.
+6. **Analyze traces**: Use flame graphs, call graph differentials, and off-CPU breakdowns to identify dominant stacks. Compare against historical baselines using `perf diff` or `speedscope` saved sessions. Annotate anomalies, regression magnitude, and suspected root causes.
+7. **Quantify hotspots**: Rank top five functions, syscalls, or threads by inclusive CPU time, blocking duration, and cache-miss ratio. Map each hotspot to implicated code owners and deployment identifiers.
+8. **Recommend actions**: Draft remediation options (code fixes, configuration tuning, hardware scaling). Provide effort estimates, risk levels, and expected latency reduction per candidate. Highlight any mandatory follow-up experiments.
+9. **Plan verification**: Outline post-remediation validation steps (A/B tests, canary monitoring, synthetic checks) aligning with release policy.
+
+## Guardrails
+- Maintain system impact below a 5% increase in CPU or memory usage during sampling.
+- Prohibit profiling on canary pods without explicit product-owner approval.
+- Redact customer data and secrets from trace exports before archival.
+- Use change-management ticket IDs in all file names and S3 prefixes.
+- Respect regional data-sovereignty mandates; keep EU traces within EU storage accounts.
+
+## Deliverables
+- A profiling session log capturing commands executed, tool versions, environment specifics, and profiler rationale.
+- A trace analysis packet containing flame graph images, differential call graphs, and summary tables (CSV) for CPU and off-CPU metrics.
+- A hotspot remediation brief summarizing ranked findings, remediation options, and risk assessments.
+- Updated runbook notes referencing discovered issues, mitigations, and unresolved questions.
+
+## Verification
+- Cross-check profiler configuration against vendor documentation and internal standards prior to execution.
+- Validate trace integrity through checksum comparison and by loading artifacts in the target visualization tool.
+- Reconcile hotspot rankings with baseline telemetry to ensure signal consistency.
+- Perform peer review with a second SRE before finalizing the remediation brief.
+
+## Communication
+- Post hourly status updates in the `#perf-war-room` Slack channel, including current phase, blockers, and ETA for artifacts.
+- Escalate blockers exceeding 30 minutes to the incident commander via PagerDuty.
+- Share final reports through the performance Confluence space, tagging relevant code owners and project managers.
+- Document follow-up tasks within Jira using the profiling ticket epic, referencing artifact locations and remediation commitments.
+
+## Reference Material
+- [Linux perf Event List](https://perf.wiki.kernel.org/index.php/Tutorial#Hardware_events) for selecting precise counters.
+- [Async-profiler Documentation](https://github.com/jvm-profiling-tools/async-profiler) covering sampling modes and flame graph generation.
+- [Pixie Profiling Guide](https://docs.pixielabs.ai/tutorials/profiler) detailing Kubernetes instrumentation steps.
+- Internal "Performance Baseline Catalog" (Confluence page `PERF-42`) enumerating historical trace benchmarks and acceptance thresholds.
+
+> Follow up with stakeholders whenever baseline telemetry deviates more than two standard deviations from historical norms, and request fresh acceptance criteria if service level objectives change mid-engagement.


### PR DESCRIPTION
## Summary
- add a profiler operations runbook prompt that covers setup, trace analysis, and hotspot reporting for production services

## Testing
- not run (documentation only)


------
https://chatgpt.com/codex/tasks/task_e_6905f9302a90832d90730a964174b1b7