### PR TITLE
Add monitoring signal optimization prompt

### DIFF
--- a/.github/prompts/operate.monitors_alerts.prompt.md
+++ b/.github/prompts/operate.monitors_alerts.prompt.md
@@ -1,0 +1,74 @@
+---
+title: "Operate: Monitoring Signal Optimization"
+summary: "Directive for orchestrating dashboards, adaptive thresholds, and runbooks that suppress alert fatigue while preserving detection fidelity"
+agent: true
+audience: "Site Reliability Engineers, Observability Leads, Platform PMs"
+style: "Decisive, operations-grade prose"
+tone: "Authoritative and collaborative"
+format: "Structured Markdown with numbered directives"
+---
+
+## Context
+- The organization operates a multi-region SaaS platform with Kubernetes-based microservices, managed data stores, and event-driven processing.
+- Stakeholders include:
+  - Site Reliability Engineering (SRE) teams responsible for production operations and on-call rotations.
+  - Observability engineers who maintain telemetry pipelines and alerting infrastructure.
+  - Platform product managers who govern service-level objectives (SLOs) and incident budgets.
+  - Security operations partners who require high-fidelity alerts for compliance-relevant telemetry.
+- Current monitoring estates (Prometheus, Grafana, PagerDuty, Elastic) emit excessive low-value alerts, obscuring real incidents and eroding responder trust.
+- Existing dashboards are fragmented, thresholds are static, and runbooks lack the detail needed for rapid mitigation.
+
+## Objectives
+- Produce a cohesive monitoring improvement plan that reduces noisy alerts by at least 40% while improving time-to-detect critical regressions.
+- Deliver production-ready dashboards that visualize golden signals, SLO burn rates, and workload-specific diagnostics.
+- Implement adaptive alert thresholds leveraging historical baselines, multi-dimensional conditions, or machine learning as appropriate.
+- Author runbooks that accelerate triage, include decision trees, and codify stakeholder communication paths.
+- Ensure the system supports regulatory obligations (e.g., SOC 2, ISO 27001) and internal escalation standards.
+
+## Directives
+1. **Inventory Telemetry Assets:** Enumerate existing metrics, logs, traces, and synthetic checks. Classify each by signal owner, reliability, and relevance to top-level SLOs.
+2. **Quantify Alert Noise:** Analyze the past 90 days of alert history to measure false-positive rate, mean time between pages, responder fatigue indicators, and escalations without action.
+3. **Prioritize Services:** Map alerts to services and business capabilities. Identify high-impact services (revenue critical, customer-facing, compliance-sensitive) that warrant immediate attention.
+4. **Define Success Metrics:** Establish explicit target thresholds for alert volume, acknowledgement latency, MTTR, and customer incident leakage. Align metrics with stakeholder expectations and executive dashboards.
+5. **Design Dashboard Blueprint:** For each priority service, specify required panels, data sources, refresh intervals, and annotations. Include golden signals (latency, traffic, errors, saturation), SLO burn-down, and dependency health overlays.
+6. **Tune Thresholds Iteratively:** Develop a methodology for dynamic thresholds (e.g., percentile-based windows, Holt-Winters forecasting, anomaly detection). Document fallback rules for static thresholds where data sparsity precludes automation.
+7. **Model Alert Routing:** Define routing matrices, deduplication logic, suppression rules for known maintenance windows, and escalation ladders for unresolved incidents.
+8. **Compose Runbooks:** For every alert category, draft runbooks with prerequisites, diagnostic commands, validation steps, mitigation actions, rollback plans, and stakeholder notification templates.
+9. **Embed Feedback Loops:** Institute post-incident reviews that update dashboards, thresholds, and runbooks. Capture learnings in a change log shared across SRE, observability, and platform PM teams.
+10. **Plan Implementation Milestones:** Sequence delivery across discovery, prototype, validation, rollout, and hypercare phases. Allocate accountable owners and expected completion dates.
+11. **Validate Tooling Integrations:** Confirm compatibility with Grafana dashboard provisioning, Prometheus Alertmanager routing, PagerDuty service configuration, and Elastic alert pipelines. Note any API or Terraform modules required.
+12. **Surface Clarifications:** List unresolved dependencies, data quality gaps, or access requirements. Provide recommended follow-up questions for stakeholders when information is missing or contradictory.
+
+## Guardrails
+- Maintain conformance with SOC 2 control objectives for monitoring, logging, and incident response.
+- Preserve alert coverage for security-relevant events; do not suppress alerts tied to compliance or data-protection violations without compensating controls.
+- Ensure dashboards remain performant (<3s load time) and accessible (WCAG 2.1 AA compliance).
+- Avoid reliance on proprietary features unavailable in current licensing tiers; propose alternatives when necessary.
+- Document decisions with rationale, trade-offs, and stakeholders consulted.
+- Treat customer data as sensitive; redact examples and scrub runbook commands of secrets.
+
+## Deliverables
+- **Monitoring Rationalization Report:** Narrative document summarizing telemetry inventory, noise analysis, prioritized services, and success metrics.
+- **Dashboard Specifications:** For each dashboard, provide layout diagrams, panel definitions, query snippets, alert annotations, and ownership metadata.
+- **Threshold Tuning Playbook:** Detailed procedure for implementing dynamic and static thresholds, including algorithms, evaluation windows, sensitivity parameters, and rollback criteria.
+- **Runbook Library:** Markdown or Confluence-ready runbooks per alert category, each containing diagnostic flowcharts, communication templates, and verification checklists.
+- **Implementation Roadmap:** Milestone schedule with responsible owners, dependencies, and resource estimates.
+- **Change Log Template:** Reusable format for capturing improvements and lessons learned after each iteration or incident.
+
+## Verification
+- Cross-validate alert reductions by replaying historical telemetry through proposed thresholds and measuring precision/recall.
+- Perform stakeholder review sessions (SRE, observability, platform PM, security) to confirm dashboards and runbooks meet operational requirements.
+- Dry-run on-call simulations using the new runbooks to ensure responders can execute diagnostics and mitigations within target MTTR.
+- Execute accessibility and performance tests on dashboards before rollout.
+- Confirm that all deliverables are stored in version control with peer review sign-off.
+
+## Communication
+- Provide weekly progress updates in the shared operations channel, highlighting completed tasks, metrics movement, and next milestones.
+- Escalate blockers within 24 hours to the program sponsor and affected team leads, including recommended resolution paths.
+- Maintain a shared decision log documenting trade-offs, stakeholder approvals, and outstanding risks.
+- Upon completion, deliver an executive summary outlining achieved alert reductions, residual risks, and recommended next steps.
+
+## Reference Material
+- Link to existing SLO documentation, incident retrospectives, and telemetry schema catalogs.
+- Include references to Grafana dashboard design guides, Prometheus Alertmanager configuration docs, and PagerDuty runbook best practices.
+- Provide internal communication standards (paging etiquette, escalation matrices) and compliance policies relevant to monitoring.


### PR DESCRIPTION
## Summary
- add an operations-focused prompt for reducing alert noise through dashboards, thresholds, and runbooks

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_6905f92ac9fc832d842774b801f5fe52