### PR TITLE
Add prompt for documentation tooling evaluation spikes

### DIFF
--- a/.github/prompts/docs.tool_eval.prompt.md
+++ b/.github/prompts/docs.tool_eval.prompt.md
@@ -1,0 +1,69 @@
+---
+title: "Documentation Tool Evaluation"
+summary: "Commission agents to execute disciplined spikes, benchmark documentation tooling options, and justify recommendations with quantified risk and ROI insights."
+agent: true
+style: "Analytical"
+tone: "Directive"
+audience: "Senior documentation engineers and platform stakeholders"
+format: "Markdown report with embedded tables"
+---
+
+## Context
+- You operate as the lead evaluator inside a developer productivity guild assessing documentation automation platforms for a 3,000-engineer organization.
+- Stakeholders include documentation program managers, DevRel advocates, compliance auditors, and the CTO steering committee awaiting a go/no-go recommendation next sprint.
+- Current state mixes bespoke markdown linters, ad-hoc scripts, and manually curated wikis, yielding inconsistent doc quality and slow incident postmortems.
+- Budget approval hinges on a defensible comparison of commercial, open-source, and in-house tooling alternatives, with explicit lifecycle cost and risk trade-offs.
+- Each spike must finish within two business days, shareable across a secure Confluence space, and must stand up to scrutiny by procurement and security review boards.
+
+## Objectives
+- Produce a conclusive tooling recommendation that maximizes documentation accuracy, developer adoption, and governance compliance.
+- Demonstrate due diligence by running at least three discrete spikes covering divergent tooling archetypes (managed SaaS, open-source self-hosted, internal build).
+- Quantify projected ROI via productivity uplift, defect reduction, and operational overhead deltas over a 12-month horizon.
+- Enumerate key risks—technical, operational, compliance, vendor viability—and outline mitigation levers with ownership assignments.
+- Deliver a stakeholder-ready evaluation brief that includes rationale, data tables, and an executive-ready summary with a clear decision proposal.
+
+## Directives
+1. **Baseline Current Pain**: Collect historical metrics on documentation throughput, review latency, error rates, and maintenance burden. Source data from analytics dashboards, repo history, or survey instruments; log any gaps explicitly.
+2. **Define Evaluation Criteria**: Construct a scoring rubric with weighted categories (authoring efficiency, automation coverage, integration effort, security posture, total cost). Align weights with stakeholder priorities gathered from prior strategy docs.
+3. **Plan Spikes**: For each tooling archetype, draft a spike plan covering scope, hypotheses, exit criteria, proof-of-concept tasks, required integrations, and data capture instrumentation. Seek sign-off from the documentation program manager before execution.
+4. **Execute Spikes**: Run the spikes sequentially. Deploy sandbox environments, integrate with representative repos, and simulate realistic authoring workflows. Capture quantitative measures (setup time, lint pass rates, review turnaround) and qualitative observations (UX friction, learning curve).
+5. **Benchmark Results**: Normalize spike outputs into a comparative matrix using the pre-defined rubric. Compute weighted scores, cost projections, and ROI (e.g., hours saved per release cycle * fully-loaded engineer rate minus tooling expense).
+6. **Risk and Mitigation Analysis**: Identify failure modes such as vendor lock-in, compliance gaps (SOC 2, ISO 27001), scalability ceilings, or dependency churn. For each, estimate likelihood, impact, detection difficulty, and assign mitigation strategies with accountable roles.
+7. **Synthesize Recommendation**: Draft a decisive narrative that selects the leading option, articulates why alternatives fall short, and specifies prerequisites (training, migration plan, contract negotiations) before rollout.
+8. **Stakeholder Review Loop**: Circulate findings to DevRel, compliance, and platform operations leads. Capture feedback, reconcile contested assumptions, and document approvals or dissenting opinions.
+9. **Decision Gate Preparation**: Assemble an executive briefing (≤10 slides) summarizing ROI, risks, required investment, and adoption timeline. Ensure every claim traces back to spike evidence or cited benchmarks.
+
+## Guardrails
+- Maintain assertive, audit-ready tone; avoid conjecture lacking evidence.
+- Base all quantitative statements on observed spike data or cited industry benchmarks; annotate each with source references.
+- Restrict access to evaluation environments and data according to company security policy; sanitize sensitive information before sharing.
+- Enforce time-boxing: no spike may exceed 16 working hours without explicit director approval.
+- Never recommend a tooling change without a migration and rollback plan backed by capacity estimates.
+- Ensure all documentation adheres to corporate accessibility standards (WCAG 2.1 AA) and localization readiness guidelines.
+
+## Deliverables
+- **Evaluation Rubric**: Markdown table listing criteria, weight, scoring rationale, and evidence links.
+- **Spike Logs**: One report per spike containing setup notes, command transcripts, metrics, cost estimates, and risk observations.
+- **Comparative Matrix**: Aggregated table with weighted scores, ROI computations, and qualitative pros/cons per option.
+- **Risk Register**: Structured list or table cataloging risks, severity, likelihood, mitigations, and owners.
+- **Recommendation Brief**: Comprehensive Markdown document with executive summary, decision statement, supporting analysis, and appendices for raw data.
+- **Executive Slide Deck Outline**: Bullet-level storyboard detailing slide titles, key visuals, and narrative flow ready for presentation tooling.
+
+## Verification
+- Validate that the spike count matches or exceeds three distinct tooling categories and that each log meets the completion criteria.
+- Recalculate weighted scores and ROI figures independently to confirm arithmetic accuracy; flag discrepancies.
+- Cross-check that every deliverable references its underlying data sources and that links resolve.
+- Confirm risk register coverage includes at least one mitigation per high-impact risk and an assigned accountable owner.
+- Run a documentation style audit (e.g., Vale or custom lint) to ensure all outputs meet language and formatting standards.
+- Perform a stakeholder sign-off checklist capturing approval status from program management, compliance, and platform operations.
+
+## Communication
+- Provide daily progress updates in the evaluation channel summarizing completed tasks, metrics captured, and upcoming steps.
+- Escalate blockers within four business hours, specifying impact, required decision-maker, and fallback actions.
+- Log stakeholder feedback verbatim with timestamps, disposition, and follow-up actions in the evaluation brief appendix.
+- Prepare a final readout session with Q&A, ensuring questions are captured, answered, and reflected in the deliverables.
+
+## Reference Material
+- Link prior documentation tooling retrospectives, governance policies, security standards, and procurement playbooks relevant to evaluation (append as reference IDs or URLs).
+- Cite industry benchmarks for documentation throughput, automation ROI, and compliance best practices when invoking comparative data.
+- Include templates for spike reporting, risk registers, and executive briefings to accelerate execution.


### PR DESCRIPTION
## Summary
- add a directive prompt for evaluating documentation tooling options via structured spikes
- outline objectives, guardrails, deliverables, and verification steps tailored to tooling assessments

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_6905f9231dc8832d9b31421271fbba5c