### PR TITLE
Add onboarding documentation prompt

### DIFF
--- a/.github/prompts/docs.onboarding.prompt.md
+++ b/.github/prompts/docs.onboarding.prompt.md
@@ -1,0 +1,61 @@
+---
+title: "Documentation Onboarding Orchestrator"
+summary: "Guide a documentation-focused agent to craft onboarding checklists, progressive learning paths, and buddy-program scripts for new team members"
+agent: true
+style: "Directive and supportive"
+audience: "Technical writers, developer advocates, and engineering managers"
+format: "Markdown with nested lists and tables where relevant"
+---
+
+## Context
+The organization maintains a living documentation hub that equips engineers, technical writers, and cross-functional partners to succeed during their first 90 days. Stakeholders include documentation leads, engineering managers, people operations, and onboarding buddies. The agent operates within a version-controlled knowledge base that mirrors production systems, so each artifact must reflect current tooling, security obligations, and collaboration etiquette. The onboarding program supports distributed teams across time zones, requiring asynchronous-friendly materials that reinforce inclusive communication norms and accessible formatting.
+
+## Objectives
+- Deliver role-aware onboarding checklists, learning paths, and buddy scripts tailored to documentation-centric teams.
+- Encode success criteria such as completion milestones, capability demonstrations, and feedback loops that ensure newcomers reach defined competency levels within 30, 60, and 90 days.
+- Harmonize the artifacts with company style guides, product architecture references, and compliance standards while highlighting dependencies on existing repositories or internal platforms.
+- Equip buddies and managers with actionable prompts that encourage psychological safety, knowledge-sharing, and proactive risk detection.
+
+## Directives
+1. Audit existing documentation assets, onboarding policies, and tool stacks to capture authoritative sources, access requirements, and training prerequisites.
+2. Segment onboarding personas (e.g., technical writer, developer advocate, documentation engineer) and capture unique goals, required systems, and primary stakeholders for each persona.
+3. Draft an end-to-end onboarding checklist for each persona that sequences tasks chronologically across pre-boarding, Day 1, Week 1, 30-day, 60-day, and 90-day milestones, annotating owners, dependencies, and success signals.
+4. Construct a multi-phase learning path per persona that maps core knowledge domains, suggested resources, experiential assignments, and validation mechanisms such as pair reviews, demos, or writing exercises.
+5. Produce a reusable buddy script that outlines kickoff conversation prompts, recurring sync agendas, escalation guidance, and strategies for nurturing inclusion and psychological safety.
+6. Embed callouts for security, privacy, accessibility, and localization obligations wherever the onboarding flow intersects with regulated content or sensitive systems.
+7. Recommend collaboration rituals (standups, documentation jams, async updates) and tooling (knowledge bases, issue trackers, analytics dashboards) that reinforce habit formation.
+8. Identify measurement strategies including onboarding surveys, documentation quality metrics, and time-to-first-contribution benchmarks; link each metric to responsible reviewers and reporting cadences.
+9. Highlight follow-up questions the agent should surface when prerequisites are missing, policies conflict, or resources are outdated, ensuring continuous improvement loops.
+10. Present all outputs in Markdown, using headings, tables, and nested lists to maximize readability for global audiences and screen-reader compatibility.
+
+## Guardrails
+- Adhere to company documentation style guides, inclusive language standards, and localization-ready formatting conventions.
+- Assume all artifacts will be versioned in Git; avoid proprietary formats and specify filenames or directory placements when relevant.
+- Do not invent tooling or policies without qualifiers; clearly label assumptions and request confirmation when data is uncertain.
+- Respect security classifications by segregating confidential procedures from public-facing guidance and flagging approval requirements.
+- Maintain traceability between onboarding tasks and source documents, referencing URLs, repo paths, or runbooks explicitly.
+
+## Deliverables
+- Persona-specific onboarding checklists covering pre-boarding through 90-day milestones, delivered as structured Markdown tables or nested lists with owners, dependencies, and success criteria.
+- Persona-specific learning paths detailing sequential modules, learning objectives, resources, practice activities, and validation steps.
+- A comprehensive buddy program script featuring kickoff agendas, recurring check-ins, feedback prompts, escalation pathways, and inclusive communication tips.
+- A summary table that maps artifacts to stakeholders, review cadences, and maintenance responsibilities.
+- A list of follow-up questions or data requests needed to finalize or validate any assumptions.
+
+## Verification
+- Cross-check each checklist, learning path, and buddy script against organizational policies, product architecture documentation, and compliance mandates.
+- Confirm that every deliverable references authoritative sources, includes measurable outcomes, and supports asynchronous onboarding scenarios.
+- Validate Markdown structure using a linter or manual inspection to guarantee headings, tables, and lists render correctly without syntax errors.
+- Review word choice and tone to ensure instructions are assertive, inclusive, and free from ambiguity or hedging.
+- Ensure total word count of the generated prompt (excluding frontmatter) remains between 500 and 1,000 words and that each required section is present and populated.
+
+## Communication
+- Provide a succinct kickoff summary outlining gathered inputs, identified gaps, and planned deliverable structure before drafting full artifacts.
+- Deliver interim updates via asynchronous channels (e.g., shared documents or issue trackers) highlighting progress, blockers, and decisions requiring stakeholder input.
+- Escalate risks or missing prerequisites immediately to documentation leads and onboarding coordinators, proposing mitigation steps and alternate timelines.
+- Upon completion, furnish a closing brief summarizing outcomes, validation results, and recommended next steps for maintenance or iteration.
+
+## Reference Material
+- Link to corporate documentation style guides, accessibility policies, localization checklists, and security classifications.
+- Include references to product architecture diagrams, API catalogs, platform playbooks, and existing onboarding repositories.
+- Cite knowledge base articles, recorded trainings, or community-of-practice resources that reinforce the onboarding curriculum.


### PR DESCRIPTION
## Summary
- add a documentation onboarding prompt that aligns with the generator template
- outline context, objectives, directives, guardrails, deliverables, verification, communication, and references for onboarding artifacts

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_6905f921b374832d98388daa0b2bcd77